### PR TITLE
Fixing wild hierarchy

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -56,19 +56,26 @@
     <Analyzer Include="B:\VisualStudio\Common7\IDE\Extensions\Microsoft\Visual Studio Tools for Unity\Analyzers\Microsoft.Unity.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assets\Photon\PhotonRealtime\Demos\DemoLoadBalancing\ConnectAndJoinRandomLb.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\SkewTextExample.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\SimpleScript.cs" />
+    <Compile Include="Assets\Photon\PhotonLibs\WebSocket\SocketWebTcp.cs" />
     <Compile Include="Assets\Scripts\Enemies\Enemy.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChatAppIdCheckerUI.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\AppSettingsExtensions.cs" />
+    <Compile Include="Assets\load game script\SceneSwitcher.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark01_UGUI.cs" />
     <Compile Include="Assets\Scripts\MenuButtons\NewGame.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextSelector_A.cs" />
     <Compile Include="Assets\Scripts\Health\UpdatePlayerHealth.cs" />
     <Compile Include="Assets\Scripts\Shooting\MainTurret.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChannelSelector.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexShakeA.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark04.cs" />
     <Compile Include="Assets\Scripts\Shop\TurretOffer.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\ChatController.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TextMeshProFloatingText.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\EventSystemSpawner.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexShakeB.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\EnvMapAnimator.cs" />
     <Compile Include="Assets\Scripts\Deprecated\SmartBullet.cs" />
@@ -81,11 +88,14 @@
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TextConsoleSimulator.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\ObjectSpin.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextInfoDebugTool.cs" />
+    <Compile Include="Assets\Scripts\MenuButtons\GoBackToMainMenu.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextEventCheck.cs" />
     <Compile Include="Assets\Scripts\Health\Despawn.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\ShaderPropAnimator.cs" />
     <Compile Include="Assets\Scripts\Deprecated\Moving\FollowPath.cs" />
+    <Compile Include="Assets\Photon\PhotonLibs\WebSocket\WebSocket.cs" />
     <Compile Include="Assets\Scripts\Deprecated\Moving\GoInSquares.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\TextButtonTransition.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\WarpTextExample.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_DigitValidator.cs" />
     <Compile Include="Assets\Scripts\Enemies\Spawner.cs" />
@@ -93,6 +103,7 @@
     <Compile Include="Assets\Scripts\Deprecated\Moving\GoLeftRight.cs" />
     <Compile Include="Assets\Scripts\Shop\ShopContainer.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark02.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\NamePickGui.cs" />
     <Compile Include="Assets\Scripts\Shooting\Bullet.cs" />
     <Compile Include="Assets\Scripts\MainMenuLoop.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TextMeshSpawner.cs" />
@@ -100,36 +111,25 @@
     <Compile Include="Assets\Scripts\Deprecated\Moving\ControlWithArrows.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark03.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_FrameRateCounter.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\IgnoreUiRaycastWhenInactive.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexJitter.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextEventHandler.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_TextSelector_B.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\FriendItem.cs" />
     <Compile Include="Assets\Scripts\Deprecated\ShootAtMouse.cs" />
     <Compile Include="Assets\sprite muzzle flashes\AnimatedTexture.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChatGui.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\DropdownSample.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TMP_PhoneNumberValidator.cs" />
+    <Compile Include="Assets\Scripts\MenuButtons\ShowCredits.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexColorCycler.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\TextToggleIsOnTransition.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\TeleType.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\VertexZoom.cs" />
     <Compile Include="Assets\Scripts\MainGameLoop.cs" />
+    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\OnStartDelete.cs" />
     <Compile Include="Assets\TextMesh Pro\Examples &amp; Extras\Scripts\Benchmark01.cs" />
     <Compile Include="Assets\Scripts\MenuButtons\QuitButton.cs" />
-    <Compile Include="Assets\Scripts\MenuButtons\ShowCredits.cs" />
-    <Compile Include="Assets\Scripts\MenuButtons\GoBackToMainMenu.cs" />
-    <Compile Include="Assets\load game script\SceneSwitcher.cs" />
-    <Compile Include="Assets\Photon\PhotonRealtime\Demos\DemoLoadBalancing\ConnectAndJoinRandomLb.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\NamePickGui.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChatGui.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\IgnoreUiRaycastWhenInactive.cs" />
-    <Compile Include="Assets\Photon\PhotonLibs\WebSocket\WebSocket.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\FriendItem.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\TextButtonTransition.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChannelSelector.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\OnStartDelete.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\ChatAppIdCheckerUI.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\DemoChat\AppSettingsExtensions.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\EventSystemSpawner.cs" />
-    <Compile Include="Assets\Photon\PhotonLibs\WebSocket\SocketWebTcp.cs" />
-    <Compile Include="Assets\Photon\PhotonChat\Demos\Common\TextToggleIsOnTransition.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\TextMesh Pro\Shaders\TMPro.cginc" />
@@ -413,6 +413,12 @@
     <Reference Include="UnityEditor.UnityConnectModule">
       <HintPath>A:\UnityEditor\2021.3.11f1\Editor\Data\Managed\UnityEngine\UnityEditor.UnityConnectModule.dll</HintPath>
     </Reference>
+    <Reference Include="websocket-sharp">
+      <HintPath>Assets\Photon\PhotonLibs\WebSocket\websocket-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Photon3Unity3D">
+      <HintPath>Assets\Photon\PhotonLibs\netstandard2.0\Photon3Unity3D.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.Burst.Unsafe">
       <HintPath>Library\PackageCache\com.unity.burst@1.6.6\Unity.Burst.Unsafe.dll</HintPath>
     </Reference>
@@ -433,12 +439,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>Library\PackageCache\com.unity.nuget.newtonsoft-json@3.0.2\Runtime\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="websocket-sharp">
-      <HintPath>Assets\Photon\PhotonLibs\WebSocket\websocket-sharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Photon3Unity3D">
-      <HintPath>Assets\Photon\PhotonLibs\netstandard2.0\Photon3Unity3D.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Android.Types">
       <HintPath>A:\UnityEditor\2021.3.11f1\Editor\Data\PlaybackEngines\AndroidPlayer\Unity.Android.Types.dll</HintPath>
@@ -812,15 +812,6 @@
     <Reference Include="System.Xml.Serialization">
       <HintPath>A:\UnityEditor\2021.3.11f1\Editor\Data\NetStandard\compat\2.1.0\shims\netfx\System.Xml.Serialization.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.VisualScripting.Flow.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.Flow.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.Tilemap.Extras">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Tilemap.Extras.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.Animation.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Animation.Editor.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.InternalAPIEngineBridge.001">
       <HintPath>Library\ScriptAssemblies\Unity.InternalAPIEngineBridge.001.dll</HintPath>
     </Reference>
@@ -830,14 +821,53 @@
     <Reference Include="Unity.2D.PixelPerfect">
       <HintPath>Library\ScriptAssemblies\Unity.2D.PixelPerfect.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.2D.Tilemap.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Tilemap.Editor.dll</HintPath>
-    </Reference>
     <Reference Include="PsdPlugin">
       <HintPath>Library\ScriptAssemblies\PsdPlugin.dll</HintPath>
     </Reference>
     <Reference Include="Unity.TextMeshPro.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.TextMeshPro.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.VisualScripting.State.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.State.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.IK.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.IK.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.Path.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Path.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor.UI">
+      <HintPath>Library\ScriptAssemblies\UnityEditor.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Rider.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.Rider.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>Library\ScriptAssemblies\UnityEngine.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.IK.Runtime">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.IK.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.VisualScripting.SettingsProvider.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.SettingsProvider.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.Mathematics.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.Mathematics.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.Common.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Common.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.VisualScripting.Flow.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.Flow.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.Tilemap.Extras">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Tilemap.Extras.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.Animation.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Animation.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.2D.Tilemap.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Tilemap.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Unity.VisualStudio.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.VisualStudio.Editor.dll</HintPath>
@@ -851,47 +881,26 @@
     <Reference Include="Unity.TextMeshPro">
       <HintPath>Library\ScriptAssemblies\Unity.TextMeshPro.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.VisualScripting.State.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.State.Editor.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.Burst.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.Burst.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.IK.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.IK.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Unity.2D.Sprite.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.2D.Sprite.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.2D.Path.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Path.Editor.dll</HintPath>
+    <Reference Include="Unity.2D.Psdimporter.Editor">
+      <HintPath>Library\ScriptAssemblies\Unity.2D.Psdimporter.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.VisualScripting.SettingsProvider.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.SettingsProvider.Editor.dll</HintPath>
+    <Reference Include="Unity.InternalAPIEditorBridge.001">
+      <HintPath>Library\ScriptAssemblies\Unity.InternalAPIEditorBridge.001.dll</HintPath>
     </Reference>
     <Reference Include="Unity.VisualScripting.Flow">
       <HintPath>Library\ScriptAssemblies\Unity.VisualScripting.Flow.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEditor.UI">
-      <HintPath>Library\ScriptAssemblies\UnityEditor.UI.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.PlasticSCM.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.PlasticSCM.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Rider.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.Rider.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.Psdimporter.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Psdimporter.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>Library\ScriptAssemblies\UnityEngine.UI.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.2D.Tilemap.Extras.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.2D.Tilemap.Extras.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.InternalAPIEditorBridge.001">
-      <HintPath>Library\ScriptAssemblies\Unity.InternalAPIEditorBridge.001.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core">
       <HintPath>Library\ScriptAssemblies\Unity.Services.Core.dll</HintPath>
@@ -901,9 +910,6 @@
     </Reference>
     <Reference Include="Unity.Mathematics">
       <HintPath>Library\ScriptAssemblies\Unity.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.IK.Runtime">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.IK.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Services.Core.Analytics">
       <HintPath>Library\ScriptAssemblies\Unity.Services.Core.Analytics.dll</HintPath>
@@ -926,17 +932,11 @@
     <Reference Include="Unity.Timeline.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.Timeline.Editor.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Mathematics.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.Mathematics.Editor.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.2D.Common.Runtime">
       <HintPath>Library\ScriptAssemblies\Unity.2D.Common.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Unity.2D.SpriteShape.Editor">
       <HintPath>Library\ScriptAssemblies\Unity.2D.SpriteShape.Editor.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.2D.Common.Editor">
-      <HintPath>Library\ScriptAssemblies\Unity.2D.Common.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Unity.2D.SpriteShape.Runtime">
       <HintPath>Library\ScriptAssemblies\Unity.2D.SpriteShape.Runtime.dll</HintPath>
@@ -946,9 +946,21 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="SimpleFolderIcon.csproj">
-      <Project>{56F7B636-3F2F-4548-6E34-29083A3CE242}</Project>
-      <Name>SimpleFolderIcon</Name>
+    <ProjectReference Include="PhotonChat.csproj">
+      <Project>{C2E31E66-7A2A-F5CA-5A95-A133397C0C0F}</Project>
+      <Name>PhotonChat</Name>
+    </ProjectReference>
+    <ProjectReference Include="PhotonUnityNetworking.Editor.csproj">
+      <Project>{2E051C84-8AE4-82BA-A61D-5007BE437A13}</Project>
+      <Name>PhotonUnityNetworking.Editor</Name>
+    </ProjectReference>
+    <ProjectReference Include="PhotonUnityNetworking.Utilities.PhotonPlayer.Editor.csproj">
+      <Project>{0275FB4D-8FEE-8B12-6135-D8B0ED3B74C0}</Project>
+      <Name>PhotonUnityNetworking.Utilities.PhotonPlayer.Editor</Name>
+    </ProjectReference>
+    <ProjectReference Include="PunDemos.DemoHubEditor.csproj">
+      <Project>{DB25804C-9E86-66C3-151D-1F1A04E23E65}</Project>
+      <Name>PunDemos.DemoHubEditor</Name>
     </ProjectReference>
     <ProjectReference Include="PhotonUnityNetworking.csproj">
       <Project>{818B9992-7FEC-A97A-96C6-AFDE06AC963B}</Project>
@@ -962,6 +974,10 @@
       <Project>{4950B522-F19B-6B5A-71F0-067DFBB7A893}</Project>
       <Name>PhotonUnityNetworking.Utilities.Culling.Editor</Name>
     </ProjectReference>
+    <ProjectReference Include="PhotonRealtime.csproj">
+      <Project>{59F1DB64-A8CA-4434-E724-190BC2A4F58E}</Project>
+      <Name>PhotonRealtime</Name>
+    </ProjectReference>
     <ProjectReference Include="PhotonUnityNetworking.Utilities.csproj">
       <Project>{A3747496-C099-BC3A-0A8D-73E5F9EA8722}</Project>
       <Name>PhotonUnityNetworking.Utilities</Name>
@@ -970,25 +986,9 @@
       <Project>{40DB6687-77F2-7AAD-DA8D-74F330901D66}</Project>
       <Name>PhotonUnityNetworking.Demos</Name>
     </ProjectReference>
-    <ProjectReference Include="PhotonChat.csproj">
-      <Project>{C2E31E66-7A2A-F5CA-5A95-A133397C0C0F}</Project>
-      <Name>PhotonChat</Name>
-    </ProjectReference>
-    <ProjectReference Include="PhotonUnityNetworking.Utilities.PhotonPlayer.Editor.csproj">
-      <Project>{0275FB4D-8FEE-8B12-6135-D8B0ED3B74C0}</Project>
-      <Name>PhotonUnityNetworking.Utilities.PhotonPlayer.Editor</Name>
-    </ProjectReference>
-    <ProjectReference Include="PhotonUnityNetworking.Editor.csproj">
-      <Project>{2E051C84-8AE4-82BA-A61D-5007BE437A13}</Project>
-      <Name>PhotonUnityNetworking.Editor</Name>
-    </ProjectReference>
-    <ProjectReference Include="PunDemos.DemoHubEditor.csproj">
-      <Project>{DB25804C-9E86-66C3-151D-1F1A04E23E65}</Project>
-      <Name>PunDemos.DemoHubEditor</Name>
-    </ProjectReference>
-    <ProjectReference Include="PhotonRealtime.csproj">
-      <Project>{59F1DB64-A8CA-4434-E724-190BC2A4F58E}</Project>
-      <Name>PhotonRealtime</Name>
+    <ProjectReference Include="SimpleFolderIcon.csproj">
+      <Project>{56F7B636-3F2F-4548-6E34-29083A3CE242}</Project>
+      <Name>SimpleFolderIcon</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Assets/Scenes/MenuGlowneChyba.unity
+++ b/Assets/Scenes/MenuGlowneChyba.unity
@@ -12582,7 +12582,7 @@ GameObject:
   - component: {fileID: 1380196102}
   - component: {fileID: 1380196101}
   m_Layer: 5
-  m_Name: ButtonSelectLevel
+  m_Name: ButtonJoinGame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -13262,7 +13262,7 @@ GameObject:
   - component: {fileID: 1864220330}
   - component: {fileID: 1864220329}
   m_Layer: 5
-  m_Name: ButtonLoadGame
+  m_Name: ButtonHostGame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/MenuGlowneChyba.unity
+++ b/Assets/Scenes/MenuGlowneChyba.unity
@@ -1379,6 +1379,50 @@ Transform:
   m_Father: {fileID: 778287966}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &522384608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 522384610}
+  - component: {fileID: 522384609}
+  m_Layer: 0
+  m_Name: MainMenuLoop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &522384609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522384608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08fffed3ef8f93f489aac1c330a08d11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &522384610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522384608}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -41.727764, y: 11.369206, z: 70.78056}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &552803640
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -23,7 +23,7 @@ public class Enemy : MonoBehaviour
     void Update()
     {
         Move();
-        if(currentHealth < 0)
+        if(currentHealth <= 0)
         {
             Die();
         }
@@ -45,16 +45,16 @@ public class Enemy : MonoBehaviour
             }
         } else
         {
-            //this should never execute, leaving just as fallback
-            //destroy is handled by Despawner, that also deals dmg
+            // This should never execute, leaving just as fallback
+            // destroy is handled by Despawner, that also deals dmg
             Destroy(gameObject);
         }
     }
 
     public void Die()
     {
-        //maybe add some effects to death, idk particles or
-        //animated text of how much money it gave
+        // Maybe add some effects to death, idk particles or
+        // animated text of how much money it gave
         //mainGame.GetComponent<MainGameLoop>().AddPlayerMoney(moneyReward);
         if (mainGame != null) // Had to add this check for main menu enemies
         {

--- a/Assets/Scripts/Enemies/Spawner.cs
+++ b/Assets/Scripts/Enemies/Spawner.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 public class Spawner : MonoBehaviour
 {
-    public GameObject enemy1;
+    private GameObject enemiesCollection;
     public GameObject[] enemies;
     public Transform[] waypoints;
     [Tooltip("Time inbetween spawns")]
@@ -23,6 +23,11 @@ public class Spawner : MonoBehaviour
     //public bool simpleMode = true;
     public bool isSpawnAllowed = true;
     public bool isSpawningConstantly = false;
+
+    private void Start()
+    {
+        enemiesCollection = new GameObject("EnemiesCollection");
+    }
 
     // Update is called once per frame
     void Update()
@@ -49,6 +54,7 @@ public class Spawner : MonoBehaviour
         _enemy.GetComponent<Enemy>().SetWaypoints(waypoints);
         _enemy.GetComponent<Enemy>().SetHealth(enemyHealth);
         _enemy.GetComponent<Enemy>().SetMoneyReward(moneyRewardPerEnemy);
+        _enemy.transform.SetParent(enemiesCollection.transform);
         timeSinceLastRespawn = Time.time;
         spawnCount++;
     }

--- a/Assets/Scripts/MainGameLoop.cs
+++ b/Assets/Scripts/MainGameLoop.cs
@@ -10,10 +10,10 @@ public class MainGameLoop : MonoBehaviour
 {
     public GameObject nodePrefab;
     public List<GameObject> nodes = new List<GameObject>();
-    public GameObject shopNodesCollection;
+    private GameObject shopNodesCollection;
 
     // playArenaCorners is an object that has 4 properly named child gameObjects
-    // their transform.position 's are corners of play arena
+    // Their transform.position 's are corners of play arena
     public Transform playArenaCorners;
     public Transform[] waypoints;
     public Transform[] obstacles;
@@ -49,6 +49,7 @@ public class MainGameLoop : MonoBehaviour
     {
         if (isAllowedInstantiating)
         {
+            shopNodesCollection = new GameObject("ShopNodesCollection");
             GetPlayArenaCorners();
             GenerateAndConfigureNodeMesh(topLeft, bottomRight);
         }
@@ -150,20 +151,6 @@ public class MainGameLoop : MonoBehaviour
                 }
             }
 
-            // It would be easier to change array to List
-            // Add obstacles on path
-            //for (int i = 0; i < waypoints.Length - 1; i++)
-            //{
-            //    if (waypoints[i].position.y == waypoints[i + 1].position.y)
-            //    {
-            //        // y = y, go horizontal
-            //        for (float y = waypoints[i].position.y + 1; y <= waypoints[i /+ /1].position.y; y++)
-            //        {
-            //           Transform _obstacle = Instantiate(obstacles[0], new Vector3//(waypoints[i].position.x, y, 0), Quaternion.identity);
-            //            //_obstacle.transform.parent = obstacles.;
-            //        }
-            //    }
-            //}
             
             // ---------------------------------------------------------------------------------------------
             // Remove nodes from obstacles
@@ -179,10 +166,33 @@ public class MainGameLoop : MonoBehaviour
                     }
                 }
             }
+
+
+            // ---------------------------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------
+            // My old attempts; TODO remove it 
+            // ---------------------------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------
+
+            // It would be easier to change array to List
+            // Add obstacles on path
+            //for (int i = 0; i < waypoints.Length - 1; i++)
+            //{
+            //    if (waypoints[i].position.y == waypoints[i + 1].position.y)
+            //    {
+            //        // y = y, go horizontal
+            //        for (float y = waypoints[i].position.y + 1; y <= waypoints[i /+ /1].position.y; y++)
+            //        {
+            //           Transform _obstacle = Instantiate(obstacles[0], new Vector3//(waypoints[i].position.x, y, 0), Quaternion.identity);
+            //            //_obstacle.transform.parent = obstacles.;
+            //        }
+            //    }
+            //}
+
             //remove nodes from path
             //for every pair
-                //find out if it is vertical or horizontal
-                    //go ++ and destroy in approxx position
+            //find out if it is vertical or horizontal
+            //go ++ and destroy in approxx position
             //for(int i = 0; i <= waypoints.Length - 2; i++)
             //{
             //    if (Mathf.Approximately(waypoints[i].position.x, waypoints[i//+1].position.x))
@@ -255,20 +265,21 @@ public class MainGameLoop : MonoBehaviour
             //        Debug.Log("Could not find straight line inbetween waypoints, maybe position isnt int?");
             //    }
             //}
-        } 
+            // ---------------------------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------
+            // ---------------------------------------------------------------------------------------------
+
+        }
         else
         {
-            Debug.Log("nie mamy nodes");
+            Debug.Log("Node prefabs were not set");
         }
-        Debug.Log("function ended, instantiated: " + nodesInstantiated + ", destroyed: " + nodesDestroyed);
+        Debug.Log("shopNodes instantiated: " + nodesInstantiated + ", destroyed: " + nodesDestroyed + ",  left: " + (nodesInstantiated - nodesDestroyed));
     }
 
     private void GetPlayArenaCorners()
     {
-        //topLeft = playArenaCorners.GetChild(0).transform.position;
-        //topRight = playArenaCorners.GetChild(1).transform.position;
-        //bottomLeft = playArenaCorners.GetChild(2).transform.position;
-        //bottomRight = playArenaCorners.GetChild(3).transform.position;
         foreach (Transform child in playArenaCorners)
         {
             if (child.name == "topLeft")

--- a/Assets/Scripts/MainGameLoop.cs
+++ b/Assets/Scripts/MainGameLoop.cs
@@ -10,6 +10,7 @@ public class MainGameLoop : MonoBehaviour
 {
     public GameObject nodePrefab;
     public List<GameObject> nodes = new List<GameObject>();
+    public GameObject shopNodesCollection;
 
     // playArenaCorners is an object that has 4 properly named child gameObjects
     // their transform.position 's are corners of play arena
@@ -52,7 +53,7 @@ public class MainGameLoop : MonoBehaviour
             GenerateAndConfigureNodeMesh(topLeft, bottomRight);
         }
 
-        //configure them maybe?
+        // Configure them maybe?
     }
 
     // Update is called once per frame
@@ -138,6 +139,7 @@ public class MainGameLoop : MonoBehaviour
                     //it would be better to check if node is on
                     //forbidden tile, then skip that tile
                     GameObject singleNode = Instantiate(nodePrefab, new Vector3(x, y, shopNodesZOffset), Quaternion.identity);
+                    singleNode.transform.SetParent(shopNodesCollection.transform);
                     //configure node right here and right now
                     //reduce number of nodes - we cant place them on:
                     //paths, obstacles, spawners, despawners,
@@ -147,6 +149,7 @@ public class MainGameLoop : MonoBehaviour
                     nodes.Add(singleNode);
                 }
             }
+
             // It would be easier to change array to List
             // Add obstacles on path
             //for (int i = 0; i < waypoints.Length - 1; i++)
@@ -161,8 +164,10 @@ public class MainGameLoop : MonoBehaviour
             //        }
             //    }
             //}
-
-            //remove nodes from obstacles
+            
+            // ---------------------------------------------------------------------------------------------
+            // Remove nodes from obstacles
+            // ---------------------------------------------------------------------------------------------
             foreach (GameObject node in nodes)
             {
                 foreach (Transform obstacle in obstacles)

--- a/Assets/Scripts/MenuButtons/NewGame.cs
+++ b/Assets/Scripts/MenuButtons/NewGame.cs
@@ -5,18 +5,6 @@ using UnityEngine.SceneManagement;
 
 public class NewGame : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     public void EnterNewGame()
     {
         SceneManager.LoadScene("pierwszaTestowaPlansza");

--- a/Assets/Scripts/Shooting/MainTurret.cs
+++ b/Assets/Scripts/Shooting/MainTurret.cs
@@ -13,6 +13,7 @@ public class MainTurret : MonoBehaviour
     public GameObject muzzleEffects;
     public GameObject gun;
     public GameObject shootSpawnPoint;
+    private GameObject bulletsCollection;
     private GameObject target;
     private GameObject bulletInstance;
     // Upgrade slider
@@ -77,9 +78,11 @@ public class MainTurret : MonoBehaviour
         srMuzzleEffects = transform.Find("Gun").transform.Find("Muzzle").transform.Find("MuzzleEffects").GetComponent<SpriteRenderer>();
         transform.Find("UpgradeCollider").GetComponent<UpgradeTurret>().SetUpgradeCost(upgradeCost);
         muzzleEffects.SetActive(false);
+        if (bulletsCollection == null) {
+            bulletsCollection = new GameObject("BulletsCollection");
+        }
     }
 
-    // Update is called once per frame
     void Update()
     {
         // -----------------------------------------------------------------------------
@@ -192,6 +195,7 @@ public class MainTurret : MonoBehaviour
         _bullet.GetComponent<Bullet>().SetDamage(baseBulletDamage * damageMultipliers[upgradeLevel]);
         _bullet.GetComponent<Bullet>().SetDistanceToLive(baseBulletRange * bulletRangeMultipliers[upgradeLevel]);
         _bullet.GetComponent<Bullet>().Setohk(oneHitKill);
+        _bullet.transform.SetParent(bulletsCollection.transform);
         UpdateMuzzleEffects();
         muzzleEffects.SetActive(true);
         return _bullet;

--- a/Assets/Scripts/Shop/ShopContainer.cs
+++ b/Assets/Scripts/Shop/ShopContainer.cs
@@ -23,8 +23,8 @@ public class ShopContainer : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        //close the shop if mouse is specified units away
-        //or when other shop is open
+        // Close the shop if mouse is specified units away
+        // or when other shop is open
         mouseWorldPos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
         if ((
             Vector2.Distance(mouseWorldPos, gameObject.transform.GetChild(0).transform.position) > distanceToCloseShop) 

--- a/Assets/Scripts/Shop/TurretOffer.cs
+++ b/Assets/Scripts/Shop/TurretOffer.cs
@@ -31,8 +31,7 @@ public class TurretOffer : MonoBehaviour
             CloseNode();
         } else
         {
-            //show some error; money is tight
-            Debug.Log("no moneeeeeyyyyyyy");
+            Debug.Log("Not enough money to buy a turret");
             CloseShop();
         }
     }


### PR DESCRIPTION
ShopNodes and Bullets now get instantiated as children of set parent, as to not shake the hierarchy during playtesting. Fixing target framerate to 60fps is necessary as everything is dependent of framerate. Every new turret will make a new GameObject that parents the children bullets - it may be changed in future.